### PR TITLE
check the type of record returned from the db and get the access token accordingly

### DIFF
--- a/src/Youtube.php
+++ b/src/Youtube.php
@@ -68,7 +68,7 @@ class Youtube implements YoutubeContract
             ->orderBy('created_at', 'desc')
             ->first();
 
-        return $latest ? $latest->access_token : null;
+        return $latest ? (is_array($latest) ? $latest['access_token'] : $latest->access_token ) : null;
     }
 
     /**


### PR DESCRIPTION
this PR fixes an issue when the record returned from the database query is an array, like in mongodb specific use case, where DB queries returns array.