### PR TITLE
Add illuminate support for Laravel 6 and 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": "^7.0",
-        "illuminate/support": "^5.4",
+        "illuminate/support": "^5.4|^6.0|^7.0",
         "google/apiclient": "^2.2"
     },
     "require-dev": {


### PR DESCRIPTION
I modified `composer.json` file for illuminate support with Laravel 6 and 7.

I tested this library with Laravel 7.4.0 and it's working.